### PR TITLE
Alias OSError to TimeoutError in python < 3.3

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -16,6 +16,10 @@ if sys.version_info >= (3, 0):
 else:
     from urlparse import urlparse  # noqa
 
+if sys.version_info < (3, 3):
+    # Create an alias for the exception introduced in python 3.3
+    TimeoutError = OSError
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Why:

* TimeoutError doesn't appear to exist anywhere.
* It's giving an error when timeouts actually occur.

This change addresses the need by:

* Simply remove the exception entirely.